### PR TITLE
Fix wrong identity name and docs link.

### DIFF
--- a/src/panels/KaitoPanel.ts
+++ b/src/panels/KaitoPanel.ts
@@ -344,15 +344,15 @@ export class KaitoPanelDataProvider implements PanelDataProvider<"kaito"> {
             this.authorizationClient,
             subscriptionId,
             identityResult.result.principalId!,
-            "b24988ac-6180-42a0-ab88-20f7382dd24c", // contributor role id
+            "b24988ac-6180-42a0-ab88-20f7382dd24c", // contributor role id: https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#general
             `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}`,
         );
 
         if (failed(roleAssignment)) {
-            vscode.window.showErrorMessage(
+            vscode.window.showWarningMessage(
                 `Error installing Kaito Federated Credentials and role Assignments: ${roleAssignment.error}`,
             );
-            return;
+            // return;
         }
     }
 
@@ -364,7 +364,7 @@ export class KaitoPanelDataProvider implements PanelDataProvider<"kaito"> {
         const result = await createFederatedCredential(
             this.managedServiceIdentityClient,
             nodeResourceGroup,
-            "kaito-federated-credential",
+            "kaito-federated-identity", // https://learn.microsoft.com/en-us/azure/aks/ai-toolchain-operator#establish-a-federated-identity-credential
             `ai-toolchain-operator-${clusterName}`,
             aksOidcIssuerUrl,
             `system:serviceaccount:"kube-system:kaito-gpu-provisioner"`,


### PR DESCRIPTION
Fix for wrong identity name causing crash loop mainly like this for the gpu pod:

<img width="1163" alt="Screenshot 2024-09-17 at 11 32 10 AM" src="https://github.com/user-attachments/assets/eabd7de0-d38f-426b-abae-265265689021">
